### PR TITLE
Make bower.json license property spec-conformant

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,10 +9,7 @@
       "lru cache",
       "serialized"
   ],
-  "license": {
-    "type": "MIT",
-    "url": "http://github.com/jmendiara/serialized-lru-cache/raw/master/LICENSE"
-  },
+  "license": "MIT",
   "ignore": [
     "node_modules",
     "test",


### PR DESCRIPTION
The [Bower spec says](https://github.com/bower/spec/blob/master/json.md#license) that `license` should be a string or array of strings, so putting an object in there breaks some tooling that parses `bower.json`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jmendiara/serialized-lru-cache/1)

<!-- Reviewable:end -->
